### PR TITLE
feat(cedar-cache-aside): Envoy + Rust PDP with Cedar, Redis cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,165 @@
-PROTO_DIR=proto
-OUT_DIR=generated
+# ========= Variables =========
+COMPOSE := docker compose -f infra/docker-compose.yml
+NETWORK ?= infra_default                # Change if your compose network name differs
+TENANT  ?= 11111111-1111-1111-1111-111111111111
+BASE    ?= http://localhost:8080/
+BASE_PDP?= http://localhost:8081
 
+# k6 defaults
+VUS           ?= 20
+DURATION      ?= 30s
+VUS_DENY      ?= 10
+DURATION_DENY ?= 30s
+
+# Proto (placeholder)
+PROTO_DIR ?= proto
+OUT_DIR   ?= generated
+
+# ========= Help =========
+.PHONY: help
+help:
+	@echo "Targets:"
+	@echo "  up                 - Build & start the whole stack"
+	@echo "  down               - Stop and remove containers/volumes"
+	@echo "  logs               - Tail logs for all services"
+	@echo "  logs-<svc>         - Tail logs for a service (pdp, envoy, db, redis, app)"
+	@echo "  ready              - Health checks for PDP and App"
+	@echo "  seed               - Insert demo policy set + permit policy and invalidate PDP cache"
+	@echo "  flush              - FLUSHALL Redis (clears decision cache)"
+	@echo "  curl-allow         - Protected request expected to be 200"
+	@echo "  curl-deny          - Protected request expected to be 403"
+	@echo "  k6-host            - Run k6 on host (requires k6)"
+	@echo "  k6-docker-host     - Run k6 in Docker hitting host (Linux: host-gateway)"
+	@echo "  k6-docker-compose  - Run k6 in Docker on compose network (http://envoy:8080/)"
+	@echo "  metrics            - Print first lines of PDP /metrics"
+	@echo "  psql               - Open psql inside DB container"
+	@echo "  redis-cli          - Open redis-cli inside Redis container"
+	@echo "  proto              - (placeholder) Generate SDK from $(PROTO_DIR) to $(OUT_DIR)"
+
+# ========= Infra =========
+.PHONY: up
+up:
+	$(COMPOSE) up --build -d
+
+.PHONY: down
+down:
+	$(COMPOSE) down -v
+
+.PHONY: logs
+logs:
+	$(COMPOSE) logs -f
+
+.PHONY: logs-%
+logs-%:
+	$(COMPOSE) logs -f $*
+
+.PHONY: ready
+ready:
+	@curl -sf $(BASE_PDP)/ready && echo " -> PDP ready" || (echo "PDP not ready"; exit 1)
+	@curl -sf $(BASE)/public/health >/dev/null && echo " -> App via Envoy ready" || (echo "App not ready"; exit 1)
+
+# ========= DB seed (demo) =========
+# Creates policy_set v1 (active) and a basic permit policy User::"123" -> read Document::"abc"
+.PHONY: seed
+seed:
+	@echo "Seeding demo tenant/policy (tenant=$(TENANT))..."
+	@$(COMPOSE) exec -T db psql -U postgres -d abac <<'SQL'
+	INSERT INTO policy_sets (tenant_id, version, status)
+	VALUES ('$(TENANT)', 1, 'active')
+	ON CONFLICT (tenant_id, version) DO NOTHING;
+
+	INSERT INTO policies (policy_set_id, cedar)
+	SELECT ps.id, $$permit(
+	  principal == User::"123",
+	  action   == Action::"read",
+	  resource == Document::"abc"
+	);$$
+	FROM policy_sets ps
+	WHERE ps.tenant_id = '$(TENANT)' AND ps.version = 1
+	LIMIT 1;
+	SQL
+	@$(COMPOSE) exec -T redis redis-cli PUBLISH pdp:invalidate '{"tenant_id":"$(TENANT)"}' >/dev/null
+	@echo "Seed done and PDP policy cache invalidated."
+
+# Optional: reset policies for v1 if you need to clean a bad insert
+.PHONY: seed-reset
+seed-reset:
+	@$(COMPOSE) exec -T db psql -U postgres -d abac <<'SQL'
+	DELETE FROM policies p
+	USING policy_sets ps
+	WHERE p.policy_set_id = ps.id
+	  AND ps.tenant_id = '$(TENANT)'
+	  AND ps.version = 1;
+	SQL
+	@$(COMPOSE) exec -T redis redis-cli PUBLISH pdp:invalidate '{"tenant_id":"$(TENANT)"}' >/dev/null
+	@echo "Policy set v1 cleared and PDP policy cache invalidated."
+
+.PHONY: flush
+flush:
+	$(COMPOSE) exec -T redis redis-cli FLUSHALL
+
+# ========= cURL helpers =========
+.PHONY: curl-allow
+curl-allow:
+	curl -i \
+	 -H 'x-tenant-id: $(TENANT)' \
+	 -H 'x-principal: User::"123"' \
+	 -H 'x-resource:  Document::"abc"' \
+	 -H 'x-action:    read' \
+	 $(BASE)
+
+.PHONY: curl-deny
+curl-deny:
+	curl -i \
+	 -H 'x-tenant-id: $(TENANT)' \
+	 -H 'x-principal: User::"123"' \
+	 -H 'x-resource:  Document::"nope"' \
+	 -H 'x-action:    read' \
+	 $(BASE)
+
+# ========= k6 =========
+.PHONY: k6-host
+k6-host:
+	BASE=$(BASE) TENANT_ID=$(TENANT) \
+	VUS=$(VUS) DURATION=$(DURATION) VUS_DENY=$(VUS_DENY) DURATION_DENY=$(DURATION_DENY) \
+	k6 run k6/authz_smoke.js
+
+# Linux: requires Docker 20.10+ for host-gateway
+.PHONY: k6-docker-host
+k6-docker-host:
+	docker run --rm -i \
+	 --add-host=host.docker.internal:host-gateway \
+	 -e BASE=http://host.docker.internal:8080/ \
+	 -e TENANT_ID=$(TENANT) \
+	 -e VUS=$(VUS) -e DURATION=$(DURATION) \
+	 -e VUS_DENY=$(VUS_DENY) -e DURATION_DENY=$(DURATION_DENY) \
+	 -v "$$PWD/k6:/scripts" grafana/k6 run /scripts/authz_smoke.js
+
+# Run k6 in the compose network, targeting 'envoy:8080'
+.PHONY: k6-docker-compose
+k6-docker-compose:
+	docker run --rm -i --network $(NETWORK) \
+	 -e BASE=http://envoy:8080/ \
+	 -e TENANT_ID=$(TENANT) \
+	 -e VUS=$(VUS) -e DURATION=$(DURATION) \
+	 -e VUS_DENY=$(VUS_DENY) -e DURATION_DENY=$(DURATION_DENY) \
+	 -v "$$PWD/k6:/scripts" grafana/k6 run /scripts/authz_smoke.js
+
+# ========= Utilities =========
+.PHONY: metrics
+metrics:
+	curl -s $(BASE_PDP)/metrics | head -n 50
+
+.PHONY: psql
+psql:
+	$(COMPOSE) exec db psql -U postgres -d abac
+
+.PHONY: redis-cli
+redis-cli:
+	$(COMPOSE) exec redis redis-cli
+
+# ========= Proto (placeholder) =========
 .PHONY: proto
 proto:
 	mkdir -p $(OUT_DIR)
-	@echo "👉 SDK generation..."
+	@echo "👉 SDK generation from $(PROTO_DIR) to $(OUT_DIR) ..."

--- a/README.md
+++ b/README.md
@@ -1,0 +1,227 @@
+
+# 🛡️ ABAC Platform — Envoy + PDP (Cedar) + Redis + Postgres
+
+![status](https://img.shields.io/badge/status-MVP-green) ![envoy](https://img.shields.io/badge/proxy-Envoy-0a7cff) ![rust](https://img.shields.io/badge/lang-Rust-DEA584) ![redis](https://img.shields.io/badge/cache-Redis-d82c20) ![postgres](https://img.shields.io/badge/db-Postgres-336791) ![license](https://img.shields.io/badge/license-MIT-black)
+
+**ABAC** authorization with **Envoy ext_authz (HTTP)** in front of a Node demo app, a **Rust PDP** (Cedar policies), **Postgres** (policies + attributes), **Redis** (cache-aside + pub/sub), and **Prometheus** metrics.
+
+---
+
+## ✨ Features
+
+* 🔐 **Envoy** protects everything except `/public/**`
+* 🧠 **PDP** with **Cedar** (policies, entities, context)
+* ⚡ **Redis** cache-aside (TTL + invalidation via Pub/Sub)
+* 📊 **Prometheus** at `/metrics`
+* 🗃️ **Tenant RLS** via `set_config('app.tenant_id', ...)`
+* 🧪 **k6** smoke & load authorization tests
+
+---
+
+## 🏗️ Architecture
+
+```
+client → Envoy ─(ext_authz)→ PDP (Rust/Cedar)
+            │                 ├─ Postgres (policies, attrs, audit)
+            └───────────────→ App (Node demo)
+                              └─ Redis (cache & pub/sub invalidation)
+```
+
+---
+
+## 🚀 Quickstart
+
+> Requirements: Docker + Docker Compose.
+
+```bash
+cd infra
+docker compose up --build
+
+curl -s localhost:8081/ready                # PDP
+curl -i localhost:8080/public/health        # App across Envoy
+```
+
+**Protected route (DENY by default without policy):**
+
+```bash
+curl -i \
+  -H 'x-tenant-id: 11111111-1111-1111-1111-111111111111' \
+  -H 'x-principal: User::"123"' \
+  -H 'x-resource:  Document::"abc"' \
+  -H 'x-action:    read' \
+  localhost:8080/
+```
+
+**Temporary bypass (dev only):**
+
+```bash
+curl -i \
+  -H 'x-tenant-id: 11111111-1111-1111-1111-111111111111' \
+  -H 'x-principal: User::"123"' \
+  -H 'x-resource:  Document::"abc"' \
+  -H 'x-action:    read' \
+  -H 'x-allow: 1' \
+  localhost:8080/
+```
+
+---
+
+## 🧩 AuthZ Headers (MVP)
+
+* `x-tenant-id` → tenant **UUID**
+* `x-principal` → Cedar UID (e.g. `User::"123"`)
+* `x-resource`  → Cedar UID (e.g. `Document::"abc"`)
+* `x-action`    → action (e.g. `read`)
+* `x-allow`     → **dev only** (`1` = ALLOW bridge)
+
+---
+
+## 📜 Insert a Policy (permit)
+To access you can use the following credentials (in next features im going to include .env)
+- POSTGRES_PASSWORD=postgres
+- POSTGRES_USER=postgres
+- POSTGRES_DB=abac
+
+```sql
+INSERT INTO policy_sets (tenant_id, version, status)
+VALUES ('11111111-1111-1111-1111-111111111111', 1, 'active')
+ON CONFLICT (tenant_id, version) DO NOTHING;
+
+INSERT INTO policies (policy_set_id, cedar)
+SELECT ps.id, $$permit(
+  principal == User::"123",
+  action   == Action::"read",
+  resource == Document::"abc"
+);$$
+FROM policy_sets ps
+WHERE ps.tenant_id = '11111111-1111-1111-1111-111111111111'
+  AND ps.version = 1
+LIMIT 1;
+```
+
+**Invalidate cache & test:**
+
+```bash
+docker compose exec redis redis-cli PUBLISH pdp:invalidate '{"tenant_id":"11111111-1111-1111-1111-111111111111"}'
+docker compose exec redis redis-cli FLUSHALL   # optional, clears DECISIONS
+
+curl -i \
+  -H 'x-tenant-id: 11111111-1111-1111-1111-111111111111' \
+  -H 'x-principal: User::"123"' \
+  -H 'x-resource:  Document::"abc"' \
+  -H 'x-action:    read' \
+  localhost:8080/
+```
+
+---
+
+## 🧰 PDP Endpoints
+
+* `GET /ready` → `"ok"`
+* `GET /metrics` → Prometheus exposition
+* `POST|GET /check` and `/check/*` → used by Envoy **ext_authz**
+
+---
+
+## 📈 Metrics (Prometheus)
+
+* `pdp_requests_total` (counter)
+* `pdp_latency_ms` (histogram)
+* `pdp_cache_hits_total` (counter)
+* `pdp_cache_misses_total` (counter)
+
+```bash
+curl -s localhost:8081/metrics | head -n 50
+```
+
+---
+
+## 🧪 k6 (smoke & load)
+
+File: `k6/authz_smoke.js` (thresholds ignore expected 403s; uses `authz_*_ok`).
+
+**Local host:**
+
+```bash
+BASE=http://localhost:8080/ \
+TENANT_ID=11111111-1111-1111-1111-111111111111 \
+VUS=20 DURATION=30s VUS_DENY=10 DURATION_DENY=30s \
+k6 run k6/authz_smoke.js
+```
+
+**Docker (Linux) hitting host:**
+
+```bash
+docker run --rm -i \
+  --add-host=host.docker.internal:host-gateway \
+  -e BASE=http://host.docker.internal:8080/ \
+  -e TENANT_ID=11111111-1111-1111-1111-111111111111 \
+  -e VUS=20 -e DURATION=30s \
+  -e VUS_DENY=10 -e DURATION_DENY=30s \
+  -v "$PWD/k6:/scripts" grafana/k6 run /scripts/authz_smoke.js
+```
+
+**Docker on Compose network (recommended):**
+
+```bash
+docker run --rm -i --network infra_default \
+  -e BASE=http://envoy:8080/ \
+  -e TENANT_ID=11111111-1111-1111-1111-111111111111 \
+  -e VUS=20 -e DURATION=30s \
+  -e VUS_DENY=10 -e DURATION_DENY=30s \
+  -v "$PWD/k6:/scripts" grafana/k6 run /scripts/authz_smoke.js
+```
+
+---
+
+## 🗄️ Schema (summary)
+
+* `tenants(id uuid, ...)`
+* `policy_sets(id pk, tenant_id uuid, version int, status text)`
+* `policies(id pk, policy_set_id fk, cedar text)`
+* `principals(cedar_uid text, attrs jsonb)`
+* `resources(cedar_uid text, attrs jsonb)`
+* `audit_logs(tenant_id, principal, resource, action, decision, policy_set_version, latency_ms, created_at)`
+
+> **RLS:** PDP runs `SELECT set_config('app.tenant_id', $1, true)` before reads; your schema can leverage it in RLS policies.
+
+---
+
+## 🧠 Redis cache-aside
+
+* **Key:** `pdp:decision:{sha256(tenant|principal|resource|action|context)}`
+* **TTL:** 30s (configure)
+* **Invalidation (policies):** channel `pdp:invalidate` with payload:
+
+  ```json
+  { "tenant_id": "11111111-1111-1111-1111-111111111111" }
+  ```
+
+---
+
+## 🎯 SLOs (MVP)
+
+* p95 < **10ms** with **≥80% hit ratio**
+* p99 < **25ms**
+* error rate < **0.1%**
+
+---
+
+## 🧰 Troubleshooting
+
+### Envoy returns 404 at `/`
+
+* Check access log.
+* Ensure routes: `public-route` (prefix `/public`), `root-exact` (path `/`), `protected-route` (prefix `/`).
+
+### `policy load error` / Cedar parse
+
+* Don’t escape with `\"...\"`. Use dollar-quoting `$$ ... $$` and UIDs `Type::"id"`.
+
+### TTL vs invalidation
+
+* Pub/Sub clears **policy cache in memory**; **decisions** remain until TTL or `FLUSHALL`.
+
+### Docker build “silent” / dummy binary
+
+* Rebuild without cache: `docker compose build --no-cache pdp && docker compose up pdp`.

--- a/db/migrations/0002_schema.sql
+++ b/db/migrations/0002_schema.sql
@@ -1,0 +1,134 @@
+-- Enable useful extensions
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Tenants
+CREATE TABLE IF NOT EXISTS tenants (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  name TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Policy sets 
+CREATE TABLE IF NOT EXISTS policy_sets (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  version INT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active', -- active|draft
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, version)
+);
+
+-- Policies (Cedar text)
+CREATE TABLE IF NOT EXISTS policies (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  policy_set_id UUID NOT NULL REFERENCES policy_sets(id) ON DELETE CASCADE,
+  cedar TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Principals and resources (free metadata and attributes)
+CREATE TABLE IF NOT EXISTS principals (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  cedar_uid TEXT NOT NULL, -- ej: User::"123"
+  attrs JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, cedar_uid)
+);
+
+CREATE TABLE IF NOT EXISTS resources (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  cedar_uid TEXT NOT NULL, -- ej: Document::"abc"
+  attrs JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, cedar_uid)
+);
+
+-- Additional attributes (optional by granularity)
+CREATE TABLE IF NOT EXISTS attributes (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  entity_type TEXT NOT NULL, -- 'principal'|'resource'
+  entity_uid  TEXT NOT NULL, -- Cedar UID
+  key TEXT NOT NULL,
+  value JSONB NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, entity_type, entity_uid, key)
+);
+
+-- Audit (append-only)
+CREATE TABLE IF NOT EXISTS audit_logs (
+  id BIGSERIAL PRIMARY KEY,
+  tenant_id UUID NOT NULL,
+  principal TEXT NOT NULL,
+  resource  TEXT NOT NULL,
+  action    TEXT NOT NULL,
+  decision  TEXT NOT NULL,   -- ALLOW|DENY
+  policy_set_version INT,
+  latency_ms INT NOT NULL,
+  ts TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_principals_tenant_uid ON principals(tenant_id, cedar_uid);
+CREATE INDEX IF NOT EXISTS idx_resources_tenant_uid  ON resources(tenant_id, cedar_uid);
+CREATE INDEX IF NOT EXISTS idx_attributes_lookup     ON attributes(tenant_id, entity_type, entity_uid, key);
+CREATE INDEX IF NOT EXISTS idx_audit_tenant_ts       ON audit_logs(tenant_id, ts);
+
+-- RLS by tenant
+ALTER TABLE policy_sets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE principals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE resources ENABLE ROW LEVEL SECURITY;
+ALTER TABLE attributes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_logs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY ps_rls ON policy_sets
+USING (tenant_id = current_setting('app.tenant_id', true)::uuid);
+CREATE POLICY p_rls  ON policies
+USING (policy_set_id IN (SELECT id FROM policy_sets WHERE tenant_id = current_setting('app.tenant_id', true)::uuid));
+CREATE POLICY princ_rls ON principals
+USING (tenant_id = current_setting('app.tenant_id', true)::uuid);
+CREATE POLICY res_rls ON resources
+USING (tenant_id = current_setting('app.tenant_id', true)::uuid);
+CREATE POLICY attr_rls ON attributes
+USING (tenant_id = current_setting('app.tenant_id', true)::uuid);
+CREATE POLICY audit_rls ON audit_logs
+USING (tenant_id = current_setting('app.tenant_id', true)::uuid);
+
+-- Demo seed: 1 tenant, 1 policy_set v1 with a simple ABAC policy
+INSERT INTO tenants (id, name) VALUES
+  ('11111111-1111-1111-1111-111111111111', 'demo-tenant')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO policy_sets (tenant_id, version, status)
+VALUES ('11111111-1111-1111-1111-111111111111', 1, 'active')
+ON CONFLICT DO NOTHING;
+
+WITH ps AS (
+  SELECT id FROM policy_sets WHERE tenant_id='11111111-1111-1111-1111-111111111111' AND version=1
+)
+INSERT INTO policies (policy_set_id, cedar)
+SELECT ps.id, $cedar$
+permit(
+  principal in User::"any",
+  action in [Action::"read", Action::"list"],
+  resource in Document::"any"
+) when {
+  principal.department == resource.department &&
+  context.timeOfDay in ["workhours"]
+};
+$cedar$
+FROM ps
+ON CONFLICT DO NOTHING;
+
+-- Example of entities
+INSERT INTO principals (tenant_id, cedar_uid, attrs)
+VALUES ('11111111-1111-1111-1111-111111111111', 'User::"123"', '{"department":"sales"}')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO resources (tenant_id, cedar_uid, attrs)
+VALUES ('11111111-1111-1111-1111-111111111111', 'Document::"abc"', '{"department":"sales"}')
+ON CONFLICT DO NOTHING;

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,36 +1,4 @@
-version: "3.9"
-
 services:
-  pdp:
-    build:
-      context: ../pdp
-      dockerfile: Dockerfile
-    environment:
-      - RUST_LOG=info
-      # DEFAULT_ALLOW=1  # uncomment to allow by default
-    ports:
-      - "8081:8081"   # PDP (HTTP /ready y /check)
-
-  app:
-    image: node:20
-    working_dir: /app
-    command: ["node","server.js"]
-    volumes:
-      - ../examples/app:/app
-    expose:
-      - "3000"
-
-  envoy:
-    image: envoyproxy/envoy:v1.31-latest
-    volumes:
-      - ./envoy.yaml:/etc/envoy/envoy.yaml:ro
-    depends_on:
-      - pdp
-      - app
-    ports:
-      - "8080:8080"
-      - "9901:9901"   # <— admin for debug
-
   db:
     image: postgres:15
     environment:
@@ -41,8 +9,72 @@ services:
       - "5432:5432"
     volumes:
       - ../db/migrations:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d abac"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
 
   redis:
     image: redis:7
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 3s
+      timeout: 2s
+      retries: 20
+
+  pdp:
+    build:
+      context: ../pdp
+      dockerfile: Dockerfile
+    environment:
+      - RUST_LOG=debug
+      - RUST_BACKTRACE=1
+      - DATABASE_URL=postgres://postgres:postgres@db:5432/abac
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: on-failure:5
+    ports:
+      - "8081:8081"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8081/ready"]
+      interval: 3s
+      timeout: 2s
+      retries: 20
+      start_period: 10s
+
+
+  app:
+    image: node:20
+    working_dir: /app
+    command: ["node","server.js"]
+    volumes:
+      - ../examples/app:/app
+    expose:
+      - "3000"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:3000/public/health"]
+      interval: 3s
+      timeout: 2s
+      retries: 20
+      start_period: 5s
+
+  envoy:
+    image: envoyproxy/envoy:v1.31-latest
+    volumes:
+      - ./envoy.yaml:/etc/envoy/envoy.yaml:ro
+    depends_on:
+      pdp:
+        condition: service_healthy
+      app:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+      - "9901:9901"

--- a/infra/envoy.yaml
+++ b/infra/envoy.yaml
@@ -59,16 +59,25 @@ static_resources:
                   timeout: 0.100s
                 path_prefix: /check           # build http://pdp:8081/check
                 authorization_request:
+                  # Allows Envoy to forward these original request headers to the PDP
+                  allowed_headers:
+                    patterns:
+                      - exact: "x-tenant-id"
+                      - exact: "x-principal"
+                      - exact: "x-resource"
+                      - exact: "x-action"
+                      - exact: "authorization"
+                      - exact: "x-allow"     # optional if want the smoke-test lever
+                  # ⬇️ (optional) Additional headers synthesized by Envoy to the PDP
                   headers_to_add:
-                  - key: "x-forwarded-host"
-                    value: "%REQ(:authority)%"
-                  - key: "x-forwarded-path"
-                    value: "%REQ(:path)%"
-                  - key: "x-forwarded-method"
-                    value: "%REQ(:method)%"
-                  # to test ALLOW
-                  - key: "x-allow"
-                    value: "%REQ(x-allow)%"
+                    - key: "x-forwarded-host"
+                      value: "%REQ(:authority)%"
+                    - key: "x-forwarded-path"
+                      value: "%REQ(:path)%"
+                    - key: "x-forwarded-method"
+                      value: "%REQ(:method)%"
+                    - key: "x-allow"
+                      value: "%REQ(x-allow)%"
                 authorization_response:
                   allowed_upstream_headers:
                     patterns:

--- a/k6/authz_smoke.js
+++ b/k6/authz_smoke.js
@@ -1,0 +1,86 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Rate } from 'k6/metrics';
+
+export const options = {
+  scenarios: {
+    allow_path: {
+      executor: 'constant-vus',
+      vus: __ENV.VUS ? parseInt(__ENV.VUS) : 10,
+      duration: __ENV.DURATION || '20s',
+      exec: 'allowScenario',
+    },
+    deny_path: {
+      executor: 'constant-vus',
+      vus: __ENV.VUS_DENY ? parseInt(__ENV.VUS_DENY) : 5,
+      duration: __ENV.DURATION_DENY || '20s',
+      exec: 'denyScenario',
+      startTime: '3s',
+    },
+  },
+  thresholds: {
+    'http_req_failed{expected_response:true}': ['rate<0.01'],
+    'http_req_duration{expected_response:true}': ['p(95)<300'],
+    'authz_deny_ok': ['rate==1'],
+    'authz_allow_ok': ['rate==1'],
+  },
+};
+
+const BASE = __ENV.BASE || 'http://localhost:8080/';
+const TENANT = __ENV.TENANT_ID || '11111111-1111-1111-1111-111111111111';
+
+// cusom metrics (optional)
+const allowLatency = new Trend('authz_allow_latency_ms', true);
+const denyLatency = new Trend('authz_deny_latency_ms', true);
+const allowOk = new Rate('authz_allow_ok');
+const denyOk = new Rate('authz_deny_ok');
+
+export function allowScenario() {
+  const headers = {
+    'x-tenant-id': TENANT,
+    'x-principal': 'User::"123"',
+    'x-resource':  'Document::"abc"',
+    'x-action':    'read',
+  };
+
+  const res = http.get(BASE, { headers, tags: { path: 'allow' } });
+  allowLatency.add(res.timings.duration);
+
+  const ok = check(res, {
+    'ALLOW -> status 200': (r) => r.status === 200,
+    // optional: validates the expected body
+    'ALLOW -> body contiene hello': (r) => r.status !== 200 || String(r.body || '').includes('Hello'),
+  });
+  allowOk.add(ok);
+
+  sleep(0.1);
+}
+
+export function denyScenario() {
+  const headers = {
+    'x-tenant-id': TENANT,
+    'x-principal': 'User::"123"',
+    'x-resource':  'Document::"nope"', // resource without policy -> DENY
+    'x-action':    'read',
+  };
+
+  const res = http.get(BASE, { headers, tags: { path: 'deny' } });
+  denyLatency.add(res.timings.duration);
+
+  const ok = check(res, {
+    'DENY -> status 403': (r) => r.status === 403,
+    // Validates the structure of the PDP JSON that receive via Envoy
+    'DENY -> decision JSON': (r) => {
+      if (r.status !== 403) return false;
+      try {
+        const j = JSON.parse(r.body);
+        return j.decision && (j.decision === 'DENY' || j.decision === 'ALLOW');
+      } catch (_) {
+        return false;
+      }
+    },
+  });
+  denyOk.add(ok);
+
+  sleep(0.1);
+}

--- a/pdp/Cargo.lock
+++ b/pdp/Cargo.lock
@@ -18,12 +18,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.3",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
 ]
 
 [[package]]
@@ -34,7 +83,16 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -48,6 +106,30 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee74396bee4da70c2e27cf94762714c911725efe69d9e2672f998512a67a4ce4"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libloading",
+]
 
 [[package]]
 name = "axum"
@@ -116,14 +198,91 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97d56060ee67d285efb8001fec9d2a4c710c32efd2e14b5cbb5ba71930fc2d"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.11.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -132,10 +291,464 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cc"
+version = "1.2.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
+name = "cedar-policy"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f64f2fe68128bd57a9ec43d8e78a174194112fc15e633bc2c466b41f15cd71"
+dependencies = [
+ "cedar-policy-core",
+ "cedar-policy-validator",
+ "itertools 0.12.1",
+ "lalrpop-util",
+ "miette",
+ "nonempty",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smol_str",
+ "thiserror",
+]
+
+[[package]]
+name = "cedar-policy-core"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecb593c2e9d7f92e5eb55a80713c2c483dc9eecb389b3f09b8f0349806f2ba5"
+dependencies = [
+ "either",
+ "itertools 0.12.1",
+ "lalrpop",
+ "lalrpop-util",
+ "lazy_static",
+ "miette",
+ "nonempty",
+ "regex",
+ "rustc_lexer",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smol_str",
+ "stacker",
+ "thiserror",
+]
+
+[[package]]
+name = "cedar-policy-validator"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3efdd198425a3ce874d4af801eb7af048cbf4bcb48f23339320df78642770636"
+dependencies = [
+ "cedar-policy-core",
+ "itertools 0.12.1",
+ "lalrpop",
+ "lalrpop-util",
+ "lazy_static",
+ "miette",
+ "nonempty",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smol_str",
+ "stacker",
+ "thiserror",
+ "unicode-security",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "ena"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -153,12 +766,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -166,6 +801,51 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -179,10 +859,49 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -190,6 +909,124 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.11.4",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom",
+ "num-traits",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "http"
@@ -247,6 +1084,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -256,6 +1094,25 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rustls 0.23.32",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.3",
+ "tower-service",
 ]
 
 [[package]]
@@ -265,13 +1122,178 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -286,22 +1308,150 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libredox"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -335,16 +1485,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "metrics"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f0c8427b39666bf970460908b213ec09b3b350f20c0c2eabcbba51704a08e6"
+dependencies = [
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "indexmap 2.11.4",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4259040465c955f9f2f1a4a8a16dc46726169bca0f88e8fb2dbeced487c3e828"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
+]
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "serde",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -362,9 +1597,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nonempty"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "303e8749c804ccd6ca3b428de7fe0d86cb86bc7606bc15291f100fd487960bb8"
 
 [[package]]
 name = "nu-ansi-term"
@@ -373,6 +1630,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -389,6 +1709,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "parking_lot"
@@ -410,20 +1736,48 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pdp"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
+ "base64 0.22.1",
+ "cedar-policy",
+ "futures",
+ "hdrhistogram",
  "http",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "redis",
  "serde",
  "serde_json",
+ "sha2",
+ "sqlx",
+ "thiserror",
+ "time",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -431,6 +1785,51 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.11.4",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -445,12 +1844,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -463,12 +1959,127 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redis"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d7a6955c7511f60f3ba9e86c6d02b3c3f144f8c24b288d1f4e18074ab8bbec"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "combine",
+ "futures",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.22.4",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "ryu",
+ "tokio",
+ "tokio-retry",
+ "tokio-rustls 0.25.0",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -489,10 +2100,197 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_lexer"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86aae0c77166108c01305ee1a36a1e77289d7dc6ca0a3cd91ff4992de2d16a5"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.6",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.5.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -507,10 +2305,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc198e42d9b7510827939c9a15f5062a0c913f3371d765977e586d2fe6c16f4a"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -539,7 +2425,7 @@ checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -548,6 +2434,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
+ "indexmap 2.11.4",
  "itoa",
  "memchr",
  "ryu",
@@ -579,6 +2466,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c522100790450cf78eeac1507263d0a350d4d5b30df0c8e1fe051a10c22b376e"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.11.4",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327ada00f7d64abaac1e55a6911e90cf665aa051b9a561c7006c157f4633135e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +2529,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +2542,28 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "slab"
@@ -609,6 +2578,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +2594,301 @@ checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
+dependencies = [
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
+dependencies = [
+ "ahash",
+ "atoi",
+ "byteorder",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-channel",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashlink",
+ "hex",
+ "indexmap 2.11.4",
+ "log",
+ "memchr",
+ "once_cell",
+ "paste",
+ "percent-encoding",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlformat",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 1.0.109",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
+dependencies = [
+ "atoi",
+ "base64 0.21.7",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
+dependencies = [
+ "atoi",
+ "base64 0.21.7",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core",
+ "tracing",
+ "url",
+ "urlencoding",
+ "uuid",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -636,6 +2909,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +2971,71 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -672,7 +3065,63 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f63835928ca123f1bef57abbcd23bb2ba0ac9ae1235f1e65bda0d06e7786bd"
+dependencies = [
+ "rustls 0.23.32",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -723,7 +3172,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -766,10 +3215,125 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb421b350c9aff471779e262955939f565ec18b86c15364e6bdf0d662ca7c1f"
+
+[[package]]
+name = "unicode-security"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4ddba1535dd35ed8b61c52166b7155d7f4e4b8847cec6f48e71dc66d8b5e50"
+dependencies = [
+ "unicode-normalization",
+ "unicode-script",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -778,10 +3342,249 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -789,7 +3592,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -798,7 +3601,31 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -807,15 +3634,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -825,9 +3658,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -843,9 +3688,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -855,12 +3712,140 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]

--- a/pdp/Cargo.toml
+++ b/pdp/Cargo.toml
@@ -8,6 +8,32 @@ axum = "0.7"
 tokio = { version = "1", features = ["full"] } 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+http = "1" 
+
+anyhow = "1"
+thiserror = "1"
+
+# Cedar
+cedar-policy = "3"
+
+# DB
+sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "uuid", "json"] }
+uuid = { version = "1", features = ["serde", "v4"] }
+
+# Redis
+redis = { version = "0.25", default-features = false, features = ["tokio-rustls-comp", "connection-manager"] }
+sha2 = "0.10"
+base64 = "0.22"
+
+# Metrics / tracing
+metrics = "=0.23.0"
+metrics-exporter-prometheus = "0.15.0" 
+
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-http = "1" 
+hdrhistogram = "7"
+
+# Util
+time = { version = "0.3", features = ["macros"] }
+
+futures = "0.3"

--- a/pdp/Dockerfile
+++ b/pdp/Dockerfile
@@ -1,19 +1,23 @@
-FROM rust:1.80 as builder
+# ====== build ======
+FROM rust:1.82-slim AS builder
 WORKDIR /app
-
-# 1. Install the MUSL target for static compilation
-RUN rustup target add x86_64-unknown-linux-musl
-
-COPY Cargo.toml .
-# Dummy build to cache dependencies for the specific target
-RUN mkdir src && echo 'fn main(){}' > src/main.rs && cargo build --target x86_64-unknown-linux-musl --release
-
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends build-essential pkg-config ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+COPY Cargo.toml Cargo.lock ./
 COPY src ./src
-# 2. Compile the final binary pointing to the static target
-RUN cargo build --target x86_64-unknown-linux-musl --release
+RUN cargo build --locked --release --bin pdp \
+ && ls -l target/release/pdp
 
-FROM scratch
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/pdp /bin/pdp
+# ====== runtime ======
+FROM debian:bookworm-slim
+WORKDIR /app
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl tini \
+ && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/pdp /bin/pdp
+RUN chmod +x /bin/pdp
+ENV RUST_LOG=debug RUST_BACKTRACE=1
 EXPOSE 8081
-ENTRYPOINT ["/bin/pdp"]
-
+ENTRYPOINT ["/usr/bin/tini","--"]
+CMD ["/bin/pdp"]

--- a/pdp/src/main.rs
+++ b/pdp/src/main.rs
@@ -4,15 +4,34 @@ use axum::{
     Json, Router,
 };
 use axum::http::{HeaderMap, Method, StatusCode};
+use cedar_policy::{
+    Authorizer, Entities, EntityUid, Policy, PolicySet, Request,
+};
+use metrics_exporter_prometheus::PrometheusBuilder;
+use redis::{aio::MultiplexedConnection, AsyncCommands};
 use serde::{Deserialize, Serialize};
-use std::{env, net::SocketAddr};
-use tokio::net::TcpListener;
-use tracing::info;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use sqlx::{postgres::PgPoolOptions, PgPool, Row};
+use std::{collections::HashMap, env, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
+use thiserror::Error;
+use tokio::{net::TcpListener, sync::RwLock, time::Instant};
+use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
+use uuid::Uuid;
+use futures::StreamExt;
+use cedar_policy::Decision;
+
+const REDIS_DECISIONS_TTL_SECS: usize = 30;
+const REDIS_INVALIDATION_CHANNEL: &str = "pdp:invalidate";
 
 #[derive(Clone)]
 struct AppState {
     default_decision_allow: bool,
+    db: PgPool,
+    redis_client: redis::Client,
+    // cache de políticas en memoria por tenant (version + PolicySet)
+    policies_cache: Arc<RwLock<HashMap<Uuid, (i32, PolicySet)>>>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -21,42 +40,85 @@ struct AuthzDecision {
     reason: String,
 }
 
+#[derive(Error, Debug)]
+enum PDPError {
+    #[error("missing header {0}")]
+    MissingHeader(&'static str),
+    #[error("invalid tenant id")]
+    InvalidTenant,
+    #[error("db error: {0}")]
+    Db(#[from] sqlx::Error),
+    #[error("redis error: {0}")]
+    Redis(#[from] redis::RedisError),
+    #[error("cedar error: {0}")]
+    Cedar(String),
+    #[error("other: {0}")]
+    Other(String),
+}
+
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
+    println!("booting PDP {}", env!("CARGO_PKG_VERSION"));
+    // Logs
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into());
     tracing_subscriber::fmt().with_env_filter(filter).init();
 
+    // Prometheus (dev) — expone /metrics
+    let prom_handle = PrometheusBuilder::new().install_recorder()?;
+    metrics::gauge!("pdp_build_info", "version" => env!("CARGO_PKG_VERSION")).set(1.0);
+
+
+
+    // Flags
     let default_decision_allow = env::var("DEFAULT_ALLOW")
         .map(|v| v == "1" || v.to_lowercase() == "true")
         .unwrap_or(false);
 
-    let state = AppState { default_decision_allow };
+    // DB
+    let db_url =
+        env::var("DATABASE_URL").unwrap_or_else(|_| "postgres://postgres:postgres@db:5432/abac".into());
+    let db = PgPoolOptions::new()
+        .max_connections(10)
+        .connect(&db_url)
+        .await?;
 
+    // Redis
+    let redis_url = env::var("REDIS_URL").unwrap_or_else(|_| "redis://redis:6379".into());
+    let redis_client = redis::Client::open(redis_url.clone())?;
+
+    // In-memory policies cache + invalidation (pub/sub)
+    let policies_cache: Arc<RwLock<HashMap<Uuid, (i32, PolicySet)>>> = Arc::new(RwLock::new(HashMap::new()));
+    spawn_redis_invalidation_listener(redis_client.clone(), policies_cache.clone()).await?;
+
+    let state = AppState {
+        default_decision_allow,
+        db,
+        redis_client,
+        policies_cache,
+    };
+
+    // HTTP server
     let app = Router::new()
-        .route("/ready", get(ready))
-        // ✅ /check y /check/ y /check/*rest (Envoy do /check + original path, p.ej. "/")
-        .route("/check",            post(check_base).get(check_base))
-        .route("/check/",           post(check_base).get(check_base))
-        .route("/check/*rest",      post(check_with_rest).get(check_with_rest))
+        .route("/ready", get(|| async { "ok" }))
+        .route("/metrics", get(move || {
+            let h = prom_handle.clone();
+            async move { h.render() }
+        }))
+        // admitir /check, /check/ y /check/* (Envoy hace /check + path original)
+        .route("/check", post(check_base).get(check_base))
+        .route("/check/", post(check_base).get(check_base))
+        .route("/check/*rest", post(check_with_rest).get(check_with_rest))
         .with_state(state);
 
     let addr: SocketAddr = "0.0.0.0:8081".parse().unwrap();
-    info!("PDP HTTP (ext_authz) escuchando en {}", addr);
-
-    let listener = TcpListener::bind(addr).await.unwrap();
-    axum::serve(listener, app).await.unwrap();
+    info!("PDP listening on {}", addr);
+    let listener = TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
 }
 
-async fn ready() -> &'static str {
-    "ok"
-}
-
-async fn check_base(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-    method: Method,
-) -> (StatusCode, Json<AuthzDecision>) {
-    check_common(state, headers, method, "/").await
+async fn check_base(State(state): State<AppState>, headers: HeaderMap, method: Method) -> (StatusCode, Json<AuthzDecision>) {
+    check_impl(state, headers, method, "/").await
 }
 
 async fn check_with_rest(
@@ -65,41 +127,332 @@ async fn check_with_rest(
     method: Method,
     Path(rest): Path<String>,
 ) -> (StatusCode, Json<AuthzDecision>) {
-    let joined = format!("/{}", rest);
-    check_common(state, headers, method, &joined).await
+    let p = format!("/{}", rest);
+    check_impl(state, headers, method, &p).await
 }
 
-async fn check_common(
+async fn check_impl(
     state: AppState,
     headers: HeaderMap,
-    method: Method,
+    _method: Method,
     original_path: &str,
 ) -> (StatusCode, Json<AuthzDecision>) {
-    let allow_header = headers
-        .get("x-allow")
+    let started = Instant::now();
+
+    // Headers mínimos (temporal en MVP)
+    let tenant_id = match headers.get("x-tenant-id").and_then(|v| v.to_str().ok()).and_then(|s| Uuid::parse_str(s).ok())
+    {
+        Some(t) => t,
+        None => return deny("missing x-tenant-id"),
+    };
+
+    let principal = match headers.get("x-principal").and_then(|v| v.to_str().ok()) {
+        Some(p) => p.to_string(),
+        None => return deny("missing x-principal"),
+    };
+
+    let resource = match headers.get("x-resource").and_then(|v| v.to_str().ok()) {
+        Some(r) => r.to_string(),
+        None => return deny("missing x-resource"),
+    };
+
+    let action_str = headers
+        .get("x-action")
         .and_then(|v| v.to_str().ok())
-        .map(|s| s == "1")
-        .unwrap_or(false);
+        .unwrap_or("read")
+        .to_string();
 
-    let fwd_path   = headers.get("x-forwarded-path").and_then(|v| v.to_str().ok()).unwrap_or("-");
-    let fwd_method = headers.get("x-forwarded-method").and_then(|v| v.to_str().ok()).unwrap_or("-");
-    info!(
-        "PDP /check hit: method={}, fwd_method={}, fwd_path={}, original_path={}, x-allow={}",
-        method, fwd_method, fwd_path, original_path, allow_header
-    );
+    // Puente de demo (como Fase 0)
+    if let Some("1") = headers.get("x-allow").and_then(|v| v.to_str().ok()) {
+        return allow("allowed by x-allow: 1");
+    }
 
-    let decision = if allow_header {
-        ("ALLOW", StatusCode::OK, "allowed by x-allow: 1")
-    } else if state.default_decision_allow {
-        ("ALLOW", StatusCode::OK, "allowed by default")
-    } else {
-        ("DENY", StatusCode::FORBIDDEN, "denied by default")
+    // Contexto (MVP: fijo)
+    let ctx_json = json!({
+        "timeOfDay": "workhours",
+        "path": original_path,
+    });
+
+    // Cache key
+    let cache_key = make_cache_key(&tenant_id, &principal, &resource, &action_str, &ctx_json.to_string());
+
+    // Redis GET
+    if let Ok(mut conn) = get_redis_conn(&state.redis_client).await {
+        let cached: redis::RedisResult<Option<String>> = conn.get(&cache_key).await;
+        if let Ok(Some(v)) = cached {
+            metrics::counter!("pdp_cache_hits_total").increment(1);
+
+
+            record_latency(started.elapsed());
+            return if v == "ALLOW" { allow("cache hit") } else { deny("cache hit") };
+        }
+    }
+    metrics::counter!("pdp_cache_misses_total").increment(1);
+
+    // DB: RLS tenant
+    if let Err(e) = sqlx::query("SELECT set_config('app.tenant_id', $1, true)")
+    .bind(tenant_id.to_string())   // set_config espera text
+    .execute(&state.db)
+    .await
+    {
+        error!("set_config app.tenant_id failed: {e}");
+        record_latency(started.elapsed());
+        return deny("tenant set failed");
+    }
+
+    // Policies activas
+    let (version, pset) = match load_policies_for_tenant(&state, tenant_id).await {
+        Ok(v) => v,
+        Err(e) => {
+            error!("load policies error: {e:?}");
+            record_latency(started.elapsed());
+            return deny("policy load error");
+        }
     };
 
-    let body = AuthzDecision {
-        decision: decision.0.to_string(),
-        reason: decision.2.to_string(),
+    // Atributos
+    let principal_attrs = load_attrs(&state.db, "principals", &principal).await.unwrap_or(json!({}));
+    let resource_attrs = load_attrs(&state.db, "resources", &resource).await.unwrap_or(json!({}));
+
+    // Cedar UIDs
+    let auid = match EntityUid::from_str(&principal) {
+        Ok(u) => u,
+        Err(_) => return deny("invalid principal UID"),
+    };
+    let ruid = match EntityUid::from_str(&resource) {
+        Ok(u) => u,
+        Err(_) => return deny("invalid resource UID"),
+    };
+    let action_uid = match EntityUid::from_str(&format!(r#"Action::"{}""#, action_str)) {
+        Ok(u) => u,
+        Err(_) => return deny("invalid action"),
     };
 
-    (decision.1, Json(body))
+    // Context
+    let ctx_val = serde_json::to_value(&ctx_json).unwrap();
+    let ctx_cedar = cedar_policy::Context::from_json_value(ctx_val, None).map_err(|e| e.to_string());
+    if ctx_cedar.is_err() {
+        return deny("invalid context");
+    }
+
+    // --- Helpers para construir las entidades en dos formatos ---
+    // --- Helpers para partir Type::"id" ---
+    fn split_type_and_id(uid: &str) -> Option<(String, String)> {
+        let parts: Vec<&str> = uid.splitn(2, "::").collect();
+        if parts.len() != 2 { return None; }
+        let typ = parts[0].to_string();
+        let mut id = parts[1].trim().to_string(); // "\"123\""
+        if id.starts_with('"') && id.ends_with('"') && id.len() >= 2 {
+            id = id[1..id.len()-1].to_string();
+        }
+        Some((typ, id))
+    }
+
+    let (p_type, p_id) = match split_type_and_id(&principal) {
+        Some(x) => x,
+        None => return deny("invalid principal UID format"),
+    };
+    let (r_type, r_id) = match split_type_and_id(&resource) {
+        Some(x) => x,
+        None => return deny("invalid resource UID format"),
+    };
+
+    // ✅ Formato A (array) con uid STRING
+    let ents_a = json!([
+        { "uid": principal, "attrs": principal_attrs, "parents": [] },
+        { "uid": resource,  "attrs": resource_attrs,  "parents": [] }
+    ]);
+
+    // ✅ Formato B (array) con uid OBJETO {type,id}
+    let ents_b = json!([
+        { "uid": { "type": p_type, "id": p_id }, "attrs": principal_attrs, "parents": [] },
+        { "uid": { "type": r_type, "id": r_id }, "attrs": resource_attrs,  "parents": [] }
+    ]);
+
+    // Parse con fallback y logs
+    let entities_opt = match Entities::from_json_value(ents_a.clone(), None) {
+        Ok(e) => Some(e),
+        Err(ea) => {
+            tracing::warn!("cedar entities parse (array + string uid) failed: {ea:?}");
+            match Entities::from_json_value(ents_b.clone(), None) {
+                Ok(e) => Some(e),
+                Err(eb) => {
+                    tracing::error!(
+                        "cedar entities parse failed both formats. A_err={ea:?}  B_err={eb:?}  A_json={}  B_json={}",
+                        ents_a, ents_b
+                    );
+                    None
+                }
+            }
+        }
+    };
+
+    let Some(entities) = entities_opt else {
+        return deny("invalid entities");
+    };
+
+
+
+    // Request (nota: Cedar v3 espera Option<EntityUid> para P/A/R y Context)
+    let req = match Request::new(Some(auid), Some(action_uid), Some(ruid), ctx_cedar.unwrap(), None) {
+        Ok(r)  => r,
+        Err(_) => return deny("invalid request"),
+    };
+
+    // Autorizar
+    let authz = Authorizer::new();
+    let resp = authz.is_authorized(&req, &pset, &entities);
+    let decision = if resp.decision() == Decision::Allow { "ALLOW" } else { "DENY" };
+
+    // Cache SET
+    if let Ok(mut conn) = get_redis_conn(&state.redis_client).await {
+        let _ : redis::RedisResult<()> = conn.set_ex(&cache_key, decision, REDIS_DECISIONS_TTL_SECS as u64).await;
+    }
+
+    // Audit
+    let latency_ms = started.elapsed().as_millis() as i32;
+    let _ = sqlx::query(
+        "INSERT INTO audit_logs (tenant_id, principal, resource, action, decision, policy_set_version, latency_ms)
+         VALUES ($1,$2,$3,$4,$5,$6,$7)"
+    )
+    .bind(tenant_id)
+    .bind(&principal)
+    .bind(&resource)
+    .bind(&action_str)
+    .bind(decision)
+    .bind(version)
+    .bind(latency_ms)
+    .execute(&state.db)
+    .await;
+
+    record_latency(started.elapsed());
+
+    if decision == "ALLOW" { allow("cedar allow") } else { deny("cedar deny") }
+}
+
+fn allow(reason: &str) -> (StatusCode, Json<AuthzDecision>) {
+    (StatusCode::OK, Json(AuthzDecision{ decision: "ALLOW".into(), reason: reason.into() }))
+}
+fn deny(reason: &str) -> (StatusCode, Json<AuthzDecision>) {
+    (StatusCode::FORBIDDEN, Json(AuthzDecision{ decision: "DENY".into(), reason: reason.into() }))
+}
+
+fn make_cache_key(tenant: &Uuid, principal: &str, resource: &str, action: &str, context_json: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(tenant.as_bytes());
+    h.update(principal.as_bytes());
+    h.update(resource.as_bytes());
+    h.update(action.as_bytes());
+    h.update(context_json.as_bytes());
+    format!("pdp:decision:{:x}", h.finalize())
+}
+
+async fn load_policies_for_tenant(state: &AppState, tenant: Uuid) -> Result<(i32, PolicySet), PDPError> {
+    // memoria
+    if let Some((ver, set)) = state.policies_cache.read().await.get(&tenant).cloned() {
+        return Ok((ver, set));
+       }
+
+    // versión activa
+    let row_opt = sqlx::query(
+        r#"
+        SELECT ps.version
+        FROM policy_sets ps
+        WHERE ps.tenant_id = $1 AND ps.status='active'
+        ORDER BY ps.version DESC
+        LIMIT 1
+        "#
+    )
+    .bind(tenant)
+    .fetch_optional(&state.db)
+    .await?;
+
+    let row = row_opt.ok_or_else(|| PDPError::Other("no active policy_set".into()))?;
+    let version: i32 = row.try_get("version")?;
+
+    // políticas de esa versión
+    let rows = sqlx::query(
+        r#"
+        SELECT p.cedar
+        FROM policies p
+        JOIN policy_sets ps ON p.policy_set_id = ps.id
+        WHERE ps.tenant_id = $1 AND ps.version = $2
+        "#
+    )
+    .bind(tenant)
+    .bind(version)
+    .fetch_all(&state.db)
+    .await?;
+
+    let mut pset = PolicySet::new();
+    for (idx, r) in rows.iter().enumerate() {
+        let cedar_text: String = r.try_get("cedar")?;
+        // Cedar v3: Policy::parse(id: Option<String>, src: &str)
+        let pol = Policy::parse(Some(format!("p{}", idx)), &cedar_text)
+            .map_err(|e| PDPError::Cedar(format!("{e:?}")))?;
+        pset.add(pol).map_err(|e| PDPError::Cedar(format!("{e:?}")))?;
+    }
+
+    state.policies_cache.write().await.insert(tenant, (version, pset.clone()));
+    Ok((version, pset))
+}
+
+async fn load_attrs(db: &PgPool, table: &str, cedar_uid: &str) -> Result<serde_json::Value, PDPError> {
+    let sql = format!("SELECT attrs FROM {} WHERE cedar_uid=$1 LIMIT 1", table);
+    let row = sqlx::query(&sql).bind(cedar_uid).fetch_optional(db).await?;
+    Ok(row
+        .and_then(|r| r.try_get::<serde_json::Value, _>("attrs").ok())
+        .unwrap_or(json!({})))
+}
+
+fn record_latency(dur: Duration) {
+    let ms = dur.as_secs_f64() * 1000.0;
+
+    metrics::counter!("pdp_requests_total").increment(1);
+
+
+    metrics::histogram!("pdp_latency_ms").record(ms);
+
+}
+
+async fn get_redis_conn(client: &redis::Client) -> Result<MultiplexedConnection, redis::RedisError> {
+    client.get_multiplexed_tokio_connection().await
+}
+
+async fn spawn_redis_invalidation_listener(
+    client: redis::Client,
+    cache: Arc<RwLock<HashMap<Uuid, (i32, PolicySet)>>>,
+) -> anyhow::Result<()> {
+    tokio::spawn(async move {
+        // Para pub/sub, usamos una conexión "no multiplexada"
+       match client.get_tokio_connection().await {
+            Ok(conn) => {
+                let mut pubsub = conn.into_pubsub();
+                if let Err(e) = pubsub.subscribe(REDIS_INVALIDATION_CHANNEL).await {
+                    warn!("redis subscribe error: {e}");
+                    return;
+                }
+                info!("Subscribed to Redis invalidation channel {}", REDIS_INVALIDATION_CHANNEL);
+                loop {
+                    // on_message() devuelve un Stream; NO se await-ea directo.
+                    if let Some(msg) = pubsub.on_message().next().await {
+                        // NO uses `if let Ok(payload): Result<...>` -> usa turbofish
+                        if let Ok(payload) = msg.get_payload::<String>() {
+                            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&payload) {
+                                if let Some(tid) = v.get("tenant_id")
+                                    .and_then(|x| x.as_str())
+                                    .and_then(|s| uuid::Uuid::parse_str(s).ok())
+                                {
+                                    cache.write().await.remove(&tid);
+                                    tracing::info!("Invalidated policies cache for tenant {}", tid);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Err(e) => warn!("redis pubsub connect error: {e}"),
+        }
+    });
+    Ok(())
 }


### PR DESCRIPTION
# Summary

This PR introduces an end-to-end ABAC authorization stack: **Envoy ext_authz (HTTP)** in front of a demo Node app, a **Rust PDP** powered by **Cedar** policies, **Postgres** for policies/attributes/audit, **Redis** for decision cache-aside + invalidation, and **Prometheus** metrics.
It also adds a production-ready Docker Compose setup, a refined PDP Dockerfile (fixing the dummy-binary cache trap), a **k6** smoke/load test, and a **Makefile** with common developer tasks.

# Context & Links

* Motivation: establish a minimal yet realistic ABAC platform with clear local dev UX (one command brings everything up; simple seed and tests).
* Related: Envoy ext_authz integration; Cedar v3 policy parsing; Postgres tenant RLS via `set_config('app.tenant_id', ...)`.

# Changes

* **PDP (Rust/axum + Cedar v3)**

  * `/ready`, `/metrics`, `/check` (+ `/check/*`) endpoints
  * Policy load from Postgres (active `policy_set` per tenant)
  * Entity attributes from DB; JSON context (path/timeOfDay placeholders)
  * Authorization via `Authorizer::is_authorized`
  * Audit log insert (decision + latency + version)
  * Metrics: `pdp_requests_total`, `pdp_latency_ms`, `pdp_cache_{hits,misses}_total`
* **Redis cache-aside**

  * SHA256 key on (tenant, principal, resource, action, context)
  * TTL 30s for decisions
  * Pub/Sub invalidation channel `pdp:invalidate` (clears in-memory policy cache)
* **Postgres**

  * Init migrations for `policy_sets`, `policies`, `principals`, `resources`, `audit_logs`
  * Tenant RLS hook via `set_config('app.tenant_id', ...)`
* **Envoy**

  * ext_authz → PDP for all routes except `/public/**`
  * Pass-through headers (`x-tenant-id`, `x-principal`, `x-resource`, `x-action`; `x-allow` dev bypass)
* **Demo app (Node)**

  * `/public/health` and root protected route
* **Tooling**

  * **Docker Compose** for db/redis/pdp/app/envoy with healthchecks
  * **PDP Dockerfile** (builder + glibc runtime; no “dummy main” cache trap)
  * **k6** smoke/load script with proper thresholds (403 on deny doesn’t count as failure)
  * **Makefile**: `up`, `ready`, `seed`, `curl-allow`, `curl-deny`, `k6-*`, `flush`, `logs`, `down`
* **Docs**

  * README with quickstart, policy insert (dollar-quoting), metrics, k6 options, troubleshooting

# Screenshots / Demos (if applicable)

**Quick demo:**

```bash
make up && make ready
make seed          # creates active policy_set v1 + permit(User::"123", read, Document::"abc")
make curl-allow    # -> 200 OK
make curl-deny     # -> 403 Forbidden
make k6-docker-compose
```

**cURL (via Envoy):**

```bash
curl -i \
  -H 'x-tenant-id: 11111111-1111-1111-1111-111111111111' \
  -H 'x-principal: User::"123"' \
  -H 'x-resource:  Document::"abc"' \
  -H 'x-action:    read' \
  http://localhost:8080/
```

# How to Test

1. **Start stack**

   ```bash
   make up
   make ready
   ```
2. **Seed a policy (permit)**

   ```bash
   make seed
   ```
3. **Verify behavior**

   * Allow path:

     ```bash
     make curl-allow  # expect 200
     ```
   * Deny path:

     ```bash
     make curl-deny   # expect 403
     ```
4. **Run k6 smoke/load**

   * Inside compose network (recommended):

     ```bash
     make k6-docker-compose
     ```
   * Or on host (requires k6 installed):

     ```bash
     make k6-host
     ```
5. **Metrics**

   ```bash
   make metrics  # prints first lines of /metrics
   ```
6. **Cache notes**

   * Policy changes: publish invalidation

     ```bash
     docker compose -f infra/docker-compose.yml exec -T redis \
       redis-cli PUBLISH pdp:invalidate '{"tenant_id":"11111111-1111-1111-1111-111111111111"}'
     ```
   * Decision TTL: 30s; for immediate effect, `make flush`.

# Risk & Rollback Plan

* **Risks**

  * Mis-formatted Cedar policies can fail parsing (`policy load error`).
  * Confusion between **policy** cache invalidation (Pub/Sub) and **decision** TTL (Redis).
  * Start-up race conditions with DB/Redis (mitigated with healthchecks; PDP logs helpful).
* **Toggles**

  * `x-allow: 1` header for dev bypass (envoy→pdp→app) for quick diagnostics.
  * `DEFAULT_ALLOW` env var in PDP (default deny unless explicitly enabled).
* **Rollback**

  * `make down` to tear down stack.
  * Revert to previous commit; rebuild:

    ```bash
    docker compose -f infra/docker-compose.yml build --no-cache pdp && \
    docker compose -f infra/docker-compose.yml up -d
    ```
  * Reset policies for v1 if needed:

    ```bash
    make seed-reset
    ```

# Checklist

* [x] Integration tested locally (Envoy ↔ PDP ↔ DB/Redis/App)
* [x] k6 smoke/load script with thresholds
* [x] README updated (Quickstart, k6, Troubleshooting)
* [x] Makefile added (developer ergonomics)
* [ ] Unit/Integration tests added for PDP logic (follow-ups)
* [x] No breaking changes to external APIs (new stack)
* [ ] Security/UX review if exposing beyond local/dev

# Release Notes (optional)

Introduces an end-to-end ABAC platform: Envoy ext_authz + Rust PDP (Cedar) + Postgres + Redis with decision cache-aside and Prometheus metrics. Includes Docker Compose, Makefile tasks, and k6 smoke/load tests for immediate local validation.
